### PR TITLE
refactor: Check Blender version using normal means

### DIFF
--- a/ice_cube_data/operators/append.py
+++ b/ice_cube_data/operators/append.py
@@ -6,9 +6,7 @@ from ice_cube import root_folder, settings_file
 from ice_cube_data.utils.file_manage import getFiles,open_json
 from ice_cube_data.utils.ui_tools import CustomErrorBox
 from ice_cube_data.utils.selectors import isRigSelected
-from ice_cube_data.utils.general_func import convertStringNumbers,selectBoneCollection
-
-cur_blender_version = convertStringNumbers(list(bpy.app.version))
+from ice_cube_data.utils.general_func import selectBoneCollection
 
 def append_preset_func(self, context, rig_baked):
         files_list = []
@@ -104,7 +102,7 @@ def append_default_rig(self, context):
 
     target_name = settings_data["default_import_file"]
 
-    if cur_blender_version >= 400:
+    if bpy.app.version >= (4, 0, 0):
         blendfile = os.path.join(script_directory, f"{target_name} 4.0+.blend")
         if not os.path.exists(blendfile):
             blendfile = os.path.join(script_directory, f"{target_name}.blend")
@@ -127,7 +125,7 @@ def append_emotion_line_func(self, context):
         emotion_line_dir = root_folder+"/ice_cube_data/internal_files/rigs"
         emotion_line_dir = os.path.normpath(emotion_line_dir)
 
-        if cur_blender_version >= 400:
+        if bpy.app.version >= (4, 0, 0):
             blendfile = os.path.join(emotion_line_dir, "emotion_line 4.0+.blend")
         else:
             blendfile = os.path.join(emotion_line_dir, "emotion_line.blend")
@@ -155,13 +153,13 @@ def append_emotion_line_func(self, context):
         c["active_object"] = bpy.data.objects[str(rig.name)]
         c["selected_objects"] = obs
         c["selected_editable_objects"] = obs
-        if cur_blender_version >= 400:
+        if bpy.app.version >= (4, 0, 0):
             with context.temp_override(**c):
                 bpy.ops.object.join()
         else:
             bpy.ops.object.join(c)
         
-        if cur_blender_version >= 400:
+        if bpy.app.version >= (4, 0, 0):
             collections = rig.data.collections
             hide_layer = selectBoneCollection(collections,"hide_layer")
             merge_layer = selectBoneCollection(collections,"merge_layer")

--- a/ice_cube_data/operators/main_operators.py
+++ b/ice_cube_data/operators/main_operators.py
@@ -14,7 +14,7 @@ import math
 #Custom Functions
 from ice_cube import root_folder, dlc_id,dlc_type,dlc_author,bl_info,valid_dlcs,settings_file
 
-from ice_cube_data.utils.general_func import BlenderVersConvert, IC_FKIK_Switch, bakeIceCube, badToTheBone, convertStringNumbers, setRestPose, resetRestPose, getLanguageTranslation
+from ice_cube_data.utils.general_func import BlenderVersConvert, IC_FKIK_Switch, bakeIceCube, badToTheBone, setRestPose, resetRestPose, getLanguageTranslation
 from ice_cube_data.utils.file_manage import getFiles, open_json
 from ice_cube_data.utils.ui_tools import CustomErrorBox
 from ice_cube_data.utils.web_tools import CustomLink, ICDownloadImage
@@ -41,7 +41,6 @@ import ice_cube
 rig_pack_list = []
 rig_pack_names = []
 rig_id = "ice_cube"
-cur_blender_version = convertStringNumbers(list(bpy.app.version))
 
 internalfiles = os.path.join(root_folder, "ice_cube_data/internal_files/user_packs/rigs")
 user_packs = os.path.normpath(internalfiles)
@@ -1127,7 +1126,7 @@ class ic_update_bonelayer(bpy.types.Operator):
 
         rig = isRigSelected(context)
         
-        if cur_blender_version >= 400:
+        if bpy.app.version >= (4, 0, 0):
             rig = isRigSelected(context)
             collections = rig.data.collections
     
@@ -1254,7 +1253,7 @@ class update_default_rig(bpy.types.Operator):
 
         settings_data["default_import_file"] = name
 
-        if cur_blender_version >= 400:
+        if bpy.app.version >= (4, 0, 0):
             filepath = f"{rigs_folder}/{name} 4.0+.blend"
         else:
             filepath = f"{rigs_folder}/{name}.blend"
@@ -1303,7 +1302,7 @@ class IC_DEVONLY_UpdateInternalRig(bpy.types.Operator):
 
     def execute(self, context):
 
-        if cur_blender_version >= 400:
+        if bpy.app.version >= (4, 0, 0):
             filepath = f"{root_folder}/ice_cube_data/internal_files/rigs/Ice Cube 4.0+.blend"
             bpy.ops.wm.save_as_mainfile(filepath=filepath,copy=True)
             blend1 = f"{root_folder}/ice_cube_data/internal_files/rigs/Ice Cube 4.0+.blend1"

--- a/ice_cube_data/properties/properties.py
+++ b/ice_cube_data/properties/properties.py
@@ -8,16 +8,13 @@ from bpy.props import (StringProperty,
                         )
 
 from ice_cube_data.utils.selectors import isRigSelected
-from ice_cube_data.utils.general_func import convertStringNumbers, selectBoneCollection, getLanguageTranslation
-
-cur_blender_version = convertStringNumbers(list(bpy.app.version))
-
+from ice_cube_data.utils.general_func import selectBoneCollection, getLanguageTranslation
 
 # classes
 
 def r_fingers_update(self, context):
     if self.enable_control_linking:
-        if cur_blender_version >= 400:
+        if bpy.app.version >= (4, 0, 0):
             target_collection = selectBoneCollection(bpy.data.objects[self.name].data.collections,"Right Fingers")
             target_collection.is_visible = self.fingers_r
         else:
@@ -25,7 +22,7 @@ def r_fingers_update(self, context):
 
 def l_fingers_update(self, context):
     if self.enable_control_linking:
-        if cur_blender_version >= 400:
+        if bpy.app.version >= (4, 0, 0):
             target_collection = selectBoneCollection(bpy.data.objects[self.name].data.collections,"Left Fingers")
             target_collection.is_visible = self.fingers_l
         else:
@@ -38,7 +35,7 @@ def r_arm_ik_update(self, context):
         prop_val = 0
 
     if self.enable_control_linking:
-        if cur_blender_version >= 400:
+        if bpy.app.version >= (4, 0, 0):
             target_collection = selectBoneCollection(bpy.data.objects[self.name].data.collections,"Right Arm IK")
             target_collection.is_visible = prop_val
         else:
@@ -51,7 +48,7 @@ def l_arm_ik_update(self, context):
         prop_val = 0
 
     if self.enable_control_linking:
-        if cur_blender_version >= 400:
+        if bpy.app.version >= (4, 0, 0):
             target_collection = selectBoneCollection(bpy.data.objects[self.name].data.collections,"Left Arm IK")
             target_collection.is_visible = prop_val
         else:
@@ -64,7 +61,7 @@ def r_leg_ik_update(self, context):
         prop_val = 0
 
     if self.enable_control_linking:
-        if cur_blender_version >= 400:
+        if bpy.app.version >= (4, 0, 0):
             target_collection = selectBoneCollection(bpy.data.objects[self.name].data.collections,"Right Leg IK")
             target_collection.is_visible = prop_val
 
@@ -81,7 +78,7 @@ def l_leg_ik_update(self, context):
         prop_val = 0
 
     if self.enable_control_linking:
-        if cur_blender_version >= 400:
+        if bpy.app.version >= (4, 0, 0):
             target_collection = selectBoneCollection(bpy.data.objects[self.name].data.collections,"Left Leg IK")
             target_collection.is_visible = prop_val
 
@@ -93,7 +90,7 @@ def l_leg_ik_update(self, context):
 
 def dynamic_hair_update(self, context):
     if self.enable_control_linking:
-        if cur_blender_version >= 400:
+        if bpy.app.version >= (4, 0, 0):
             target_collection = selectBoneCollection(bpy.data.objects[self.name].data.collections,"Dynamic Hair")
             target_collection.is_visible = self.dynamichair
         else:
@@ -101,7 +98,7 @@ def dynamic_hair_update(self, context):
 
 def face_rig_update(self, context):
     if self.enable_control_linking:
-        if cur_blender_version >= 400:
+        if bpy.app.version >= (4, 0, 0):
             target_collection = selectBoneCollection(bpy.data.objects[self.name].data.collections,"Face Panel Bones")
             target_collection.is_visible = self.facerig
             

--- a/ice_cube_data/systems/search_system.py
+++ b/ice_cube_data/systems/search_system.py
@@ -1,14 +1,12 @@
 import bpy
 from bpy.props import StringProperty
 import re
-from ice_cube_data.utils.general_func import convertStringNumbers,selectBoneCollection, getLanguageTranslation
+from ice_cube_data.utils.general_func import selectBoneCollection, getLanguageTranslation
 
 
 
 
 matching_props = []
-
-cur_blender_version = convertStringNumbers(list(bpy.app.version))
 
 bpy.types.Object.ice_cube_search_filter = StringProperty(
     name="ice_cube_search_filter",
@@ -144,7 +142,7 @@ def ic_search_ui(self,context,scale):
     sep(getLanguageTranslation("ice_cube.search.terms.mouth_influence"),"mouth_influence",getLanguageTranslation("ice_cube.search.display.mouth_influence")), #Mouth Influence Controls
 
     #bone layers
-    if cur_blender_version >= 400:
+    if bpy.app.version >= (4, 0, 0):
         sep(getLanguageTranslation("ice_cube.search.terms.bonelayer.main"),"is_visible",source="bone_collection",prop_tag="Main Bones"), #Main Rig Bone Layer
         sep(getLanguageTranslation("ice_cube.search.terms.bonelayer.face"),"is_visible",source="bone_collection",prop_tag="Face Panel Bones"), #Face Panel Bone Layer
         sep(getLanguageTranslation("ice_cube.search.terms.bonelayer.armRIK"),"is_visible",source="bone_collection",prop_tag="Right Arm IK"), #Right Arm IK Bone Layer

--- a/ice_cube_data/ui/new_ui/controls.py
+++ b/ice_cube_data/ui/new_ui/controls.py
@@ -14,8 +14,8 @@ def newEnum(layout,display,source,prop,expand):
 
 
 
-def newBoneLayer(context,layout,index,text,prop_tag,cur_blender_version):
-    if cur_blender_version >= 400:
+def newBoneLayer(context,layout,index,text,prop_tag):
+    if bpy.app.version >= (4, 0, 0):
         collections = context.active_object.data.collections
         target_collection = selectBoneCollection(collections,prop_tag)
         if target_collection != None:
@@ -24,7 +24,7 @@ def newBoneLayer(context,layout,index,text,prop_tag,cur_blender_version):
         layers = context.active_object.data
         layout.prop(layers, 'layers', index=index, toggle=True, text=getLanguageTranslation(text))
 
-def controls_ui(self,context,layout,obj,scale,cur_blender_version):
+def controls_ui(self,context,layout,obj,scale):
     box = layout.box()
     box.label(text= getLanguageTranslation("ice_cube.ui.tabs.control_settings"), icon= 'NETWORK_DRIVE')
     b = box.row(align=True)
@@ -161,8 +161,8 @@ def controls_ui(self,context,layout,obj,scale,cur_blender_version):
         face_row.label(text=getLanguageTranslation("ice_cube.ui.tabs.face_bones"),icon='GROUP_BONE')
         if button_toggle(obj,face_row,"bone_set_face"):
             face_row = face_box.row(align=True)
-            newBoneLayer(context,face_row,0,'ice_cube.ui.bone_layers.main','Main Bones',cur_blender_version)
-            newBoneLayer(context,face_row,23,'ice_cube.ui.bone_layers.face_panel','Face Panel Bones',cur_blender_version)
+            newBoneLayer(context,face_row,0,'ice_cube.ui.bone_layers.main','Main Bones')
+            newBoneLayer(context,face_row,23,'ice_cube.ui.bone_layers.face_panel','Face Panel Bones')
         
         bonelayer_row = bonelayer_box.row(align=True)
         arm_box = bonelayer_row.box()
@@ -172,14 +172,14 @@ def controls_ui(self,context,layout,obj,scale,cur_blender_version):
             arm_row = arm_box.row(align=True)
             #right
             arm_col = arm_row.column(align=True)
-            newBoneLayer(context,arm_col,1,'ice_cube.ui.bone_layers.right_arm_ik','Right Arm IK',cur_blender_version)
-            newBoneLayer(context,arm_col,17,'ice_cube.ui.bone_layers.right_arm_fk','Right Arm FK',cur_blender_version)
-            newBoneLayer(context,arm_col,5,'ice_cube.ui.bone_layers.right_fingers','Right Fingers',cur_blender_version)
+            newBoneLayer(context,arm_col,1,'ice_cube.ui.bone_layers.right_arm_ik','Right Arm IK')
+            newBoneLayer(context,arm_col,17,'ice_cube.ui.bone_layers.right_arm_fk','Right Arm FK')
+            newBoneLayer(context,arm_col,5,'ice_cube.ui.bone_layers.right_fingers','Right Fingers')
             #left
             arm_col = arm_row.column(align=True)
-            newBoneLayer(context,arm_col,2,'ice_cube.ui.bone_layers.left_arm_ik','Left Arm IK',cur_blender_version)
-            newBoneLayer(context,arm_col,18,'ice_cube.ui.bone_layers.left_arm_fk','Left Arm FK',cur_blender_version)
-            newBoneLayer(context,arm_col,21,'ice_cube.ui.bone_layers.left_fingers','Left Fingers',cur_blender_version)
+            newBoneLayer(context,arm_col,2,'ice_cube.ui.bone_layers.left_arm_ik','Left Arm IK')
+            newBoneLayer(context,arm_col,18,'ice_cube.ui.bone_layers.left_arm_fk','Left Arm FK')
+            newBoneLayer(context,arm_col,21,'ice_cube.ui.bone_layers.left_fingers','Left Fingers')
         
         bonelayer_row = bonelayer_box.row(align=True)
         leg_box = bonelayer_row.box()
@@ -189,12 +189,12 @@ def controls_ui(self,context,layout,obj,scale,cur_blender_version):
             leg_row = leg_box.row(align=True)
             #right
             leg_col = leg_row.column(align=True)
-            newBoneLayer(context,leg_col,3,'ice_cube.ui.bone_layers.right_leg_ik','Right Leg IK',cur_blender_version)
-            newBoneLayer(context,leg_col,19,'ice_cube.ui.bone_layers.right_leg_fk','Right Leg FK',cur_blender_version)
+            newBoneLayer(context,leg_col,3,'ice_cube.ui.bone_layers.right_leg_ik','Right Leg IK')
+            newBoneLayer(context,leg_col,19,'ice_cube.ui.bone_layers.right_leg_fk','Right Leg FK')
             #left
             leg_col = leg_row.column(align=True)
-            newBoneLayer(context,leg_col,4,'ice_cube.ui.bone_layers.left_leg_ik','Left Leg IK',cur_blender_version)
-            newBoneLayer(context,leg_col,20,'ice_cube.ui.bone_layers.left_leg_fk','Left Leg FK',cur_blender_version)
+            newBoneLayer(context,leg_col,4,'ice_cube.ui.bone_layers.left_leg_ik','Left Leg IK')
+            newBoneLayer(context,leg_col,20,'ice_cube.ui.bone_layers.left_leg_fk','Left Leg FK')
         
         bonelayer_row = bonelayer_box.row(align=True)
         tweak_box = bonelayer_row.box()
@@ -203,13 +203,13 @@ def controls_ui(self,context,layout,obj,scale,cur_blender_version):
         if button_toggle(obj,tweak_row,"bone_set_tweak"):
             tweak_row = tweak_box.row(align=True)
             tweak_col = tweak_row.column(align=True)
-            newBoneLayer(context,tweak_col,7,'ice_cube.ui.bone_layers.body_tweak','Body Tweak',cur_blender_version)
-            newBoneLayer(context,tweak_col,8,'ice_cube.ui.bone_layers.right_arm_tweak','Right Arm Tweak',cur_blender_version)
-            newBoneLayer(context,tweak_col,24,'ice_cube.ui.bone_layers.right_leg_tweak','Right Leg Tweak',cur_blender_version)
+            newBoneLayer(context,tweak_col,7,'ice_cube.ui.bone_layers.body_tweak','Body Tweak')
+            newBoneLayer(context,tweak_col,8,'ice_cube.ui.bone_layers.right_arm_tweak','Right Arm Tweak')
+            newBoneLayer(context,tweak_col,24,'ice_cube.ui.bone_layers.right_leg_tweak','Right Leg Tweak')
             tweak_col = tweak_row.column(align=True)
-            newBoneLayer(context,tweak_col,16,'ice_cube.ui.bone_layers.face_tweak','Face Tweak',cur_blender_version)
-            newBoneLayer(context,tweak_col,9,'ice_cube.ui.bone_layers.left_arm_tweak','Left Arm Tweak',cur_blender_version)
-            newBoneLayer(context,tweak_col,25,'ice_cube.ui.bone_layers.left_leg_tweak','Left Leg Tweak',cur_blender_version)
+            newBoneLayer(context,tweak_col,16,'ice_cube.ui.bone_layers.face_tweak','Face Tweak')
+            newBoneLayer(context,tweak_col,9,'ice_cube.ui.bone_layers.left_arm_tweak','Left Arm Tweak')
+            newBoneLayer(context,tweak_col,25,'ice_cube.ui.bone_layers.left_leg_tweak','Left Leg Tweak')
         
         bonelayer_row = bonelayer_box.row(align=True)
         misc_box = bonelayer_row.box()
@@ -219,14 +219,14 @@ def controls_ui(self,context,layout,obj,scale,cur_blender_version):
             misc_row = misc_box.row(align=True)
             misc_col = misc_row.column(align=True)
 
-            newBoneLayer(context,misc_col,10,'ice_cube.ui.bone_layers.twist','Twist',cur_blender_version)
-            newBoneLayer(context,misc_col,6,'ice_cube.ui.bone_layers.dynamic_hair','Dynamic Hair',cur_blender_version)
+            newBoneLayer(context,misc_col,10,'ice_cube.ui.bone_layers.twist','Twist')
+            newBoneLayer(context,misc_col,6,'ice_cube.ui.bone_layers.dynamic_hair','Dynamic Hair')
             misc_col = misc_row.column(align=True)
-            newBoneLayer(context,misc_col,22,'ice_cube.ui.bone_layers.extras','Extra',cur_blender_version)
-            newBoneLayer(context,misc_col,26,'ice_cube.ui.bone_layers.footroll','Footroll',cur_blender_version)
+            newBoneLayer(context,misc_col,22,'ice_cube.ui.bone_layers.extras','Extra')
+            newBoneLayer(context,misc_col,26,'ice_cube.ui.bone_layers.footroll','Footroll')
             misc_col = misc_row.column(align=True)
-            newBoneLayer(context,misc_col,15,'ice_cube.ui.bone_layers.emotion_bones','Emotion Bones',cur_blender_version)
-            newBoneLayer(context,misc_col,27,'ice_cube.ui.bone_layers.cartoon_mouth','Cartoon Mouth',cur_blender_version)
+            newBoneLayer(context,misc_col,15,'ice_cube.ui.bone_layers.emotion_bones','Emotion Bones')
+            newBoneLayer(context,misc_col,27,'ice_cube.ui.bone_layers.cartoon_mouth','Cartoon Mouth')
 
 
 

--- a/ice_cube_data/ui/new_ui/materials.py
+++ b/ice_cube_data/ui/new_ui/materials.py
@@ -3,15 +3,13 @@ import bpy
 
 from ice_cube_data.utils.ui_tools import button_toggle
 from ice_cube_data.utils.selectors import isRigSelected,mat_holder_func
-from ice_cube_data.utils.general_func import convertStringNumbers, getLanguageTranslation
+from ice_cube_data.utils.general_func import getLanguageTranslation
 
 def newEnum(layout,display,source,prop,expand):
     if display != "":
         layout.label(text=display)
     layout.prop(data=source,property=prop,expand=expand)
 
-
-cur_blender_version = convertStringNumbers(list(bpy.app.version))
 
 def material_skin_ui(self, context, layout, scale):
     obj = context.object

--- a/ice_cube_data/utils/general_func.py
+++ b/ice_cube_data/utils/general_func.py
@@ -227,11 +227,6 @@ def IC_FKIK_Switch(context, type, limb):
             Leg_FK_L_upper.rotation_quaternion = [1,0,0,0]
             Leg_FK_L_lower.rotation_quaternion = [1,0,0,0]
 
-def convertStringNumbers(list):
-    s = [str(i) for i in list]
-    res = int("".join(s))
-    return(res)
-
 def selectBoneCollection(collections,target):
     for collection in collections:
         try:
@@ -241,14 +236,12 @@ def selectBoneCollection(collections,target):
         except:
             pass
 
-cur_blender_version = convertStringNumbers(list(bpy.app.version))
-
 def applyMod(mesh,modifier):
 
     c = {'object': mesh}
 
     try:
-        if cur_blender_version >= 400:
+        if bpy.app.version >= (4, 0, 0):
             with bpy.context.temp_override(**c):
                 bpy.ops.object.modifier_apply(modifier=modifier)
         else:
@@ -444,7 +437,7 @@ def bakeIceCube(self,context,override=False):
         for mod in modifier_to_apply:
             applyMod(mesh,mod)
     
-        if cur_blender_version >= 400:
+        if bpy.app.version >= (4, 0, 0):
             collections = rig.data.collections
             twist_collection = selectBoneCollection(collections,"Twist")
             twist_active = twist_collection.is_visible
@@ -597,7 +590,7 @@ def newCopyRotation(source,target,subtarget,name):
     copy_rotation.target_space = 'LOCAL'
     copy_rotation.owner_space = 'LOCAL'
     context_override = {'active_pose_bone' : source}
-    if cur_blender_version >= 400:
+    if bpy.app.version >= (4, 0, 0):
         with bpy.context.temp_override(**context_override):
             bpy.ops.constraint.move_to_index(constraint=copy_rotation.name,owner='BONE',index=0)
     else:
@@ -612,7 +605,7 @@ def newCopyLocation(source,target,subtarget,name):
     copy_location.owner_space = 'LOCAL'
     copy_location.use_offset = True
     context_override = {'active_pose_bone' : source}
-    if cur_blender_version >= 400:
+    if bpy.app.version >= (4, 0, 0):
         with bpy.context.temp_override(**context_override):
             bpy.ops.constraint.move_to_index(constraint=copy_location.name,owner='BONE',index=0)
     else:
@@ -627,7 +620,7 @@ def newCopyScale(source,target,subtarget,name):
     copy_scale.owner_space = 'LOCAL'
     copy_scale.use_offset = True
     context_override = {'active_pose_bone' : source}
-    if cur_blender_version >= 400:
+    if bpy.app.version >= (4, 0, 0):
         with bpy.context.temp_override(**context_override):
             bpy.ops.constraint.move_to_index(constraint=copy_scale.name,owner='BONE',index=0)
     else:
@@ -701,7 +694,7 @@ def setRestPose(context):
             if reset_loc:
                 newCopyLocation(bone,rig,new_bone,f"{bone.name}_{new_bone.name}_LOCATION")
             
-            if cur_blender_version >= 400:
+            if bpy.app.version >= (4, 0, 0):
                 collections = rig.data.collections
                 custom_default = selectBoneCollection(collections,"Custom Default")
                 custom_default.assign(new_bone)
@@ -743,7 +736,7 @@ def resetRestPose(context):
                 rotation_constraint = bone.constraints.get(f"{bone.name}_{boneOverrideData}_ROTATION")
                 scale_constraint = bone.constraints.get(f"{bone.name}_{boneOverrideData}_SCALE")
 
-                if cur_blender_version >= 400:
+                if bpy.app.version >= (4, 0, 0):
                     if location_constraint:
                         context_override = {'active_pose_bone' : bone}
                         with context.temp_override(**context_override):

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ from ice_cube_data.systems import inventory_system, skin_downloader,search_syste
 #Custom Functions
 from ice_cube_data.utils.selectors import isRigSelected, main_face
 from ice_cube_data.utils.file_manage import getFiles, open_json
-from ice_cube_data.utils.general_func import GetListIndex,convertStringNumbers, getLanguageTranslation
+from ice_cube_data.utils.general_func import GetListIndex, getLanguageTranslation
 
 #UI Panels
 from ice_cube_data.ui import old_credits_info, credits_info
@@ -39,8 +39,6 @@ rig_id = "ice_cube"
 
 
 #InFileDefs
-
-cur_blender_version = convertStringNumbers(list(bpy.app.version))
 
 def presets_menu(self, context):
     """presets menu thing"""
@@ -257,7 +255,7 @@ class UIPANEL_PT_IceCube(bpy.types.Panel):
         except:
             skin_mat = False
 
-        if cur_blender_version >= 400:
+        if bpy.app.version >= (4, 0, 0):
             collections = rig.data.collections
 
             if not "UpdatedTo4.0" in rig.data and not "Main Bones" in collections:
@@ -308,7 +306,7 @@ class UIPANEL_PT_IceCube(bpy.types.Panel):
                     elif obj.get("style_menu_switcher") == 1:
                         style.mesh_style_ui(self,context,layout,obj,preview_collections,scale)
                 elif cur_panel == 1: #Controls
-                        controls.controls_ui(self,context,layout,obj,scale,cur_blender_version)
+                        controls.controls_ui(self,context,layout,obj,scale)
                 elif cur_panel == 2: #Materials
                     b= box.row(align=True)
                     b.prop(obj,"material_menu_switcher",expand=True)


### PR DESCRIPTION
Previously Blender versions were checked by converting the bpy.app.version tuple to a list, then to a string, then to an integer. However, these conversions aren't needed, and as bpy.app.version can be checked directly as followed:

```py
bpy.app.version >= (MAJOR, MINOR, BUGFIX)
```

this also simplifies many of the functions by removing the need for an additional parameter.